### PR TITLE
V3.8 test (Test for uChat built from MM master)

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.mattermost.desktop",
+  "appId": "com.uchat.desktop",
   "directories": {
     "buildResources": "resources",
     "app": "src",
@@ -22,12 +22,12 @@
   ],
   "protocols": [
     {
-      "name": "Mattermost",
-      "schemes": ["mattermost"]
+      "name": "uChat",
+      "schemes": ["uchat"]
     }
   ],
   "deb": {
-    "synopsis": "Mattermost"
+    "synopsis": "uChat"
   },
   "linux": {
     "category": "InstantMessaging",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "mattermost-desktop",
-  "productName": "Mattermost",
+  "name": "uchat-desktop",
+  "productName": "uChat",
   "version": "3.7.1",
-  "description": "Mattermost",
+  "description": "uChat",
   "main": "main.js",
-  "author": "Mattermost, Inc. <feedback@mattermost.com>",
+  "author": "uChat, Inc. <feedback@uchat.com>",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=4.2.0"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mattermost/desktop.git"
+    "url": "git://github.com/uber-uchat/desktop.git"
   },
   "scripts": {
     "postinstall": "install-app-deps && npm run extract-dict",
@@ -28,9 +28,9 @@
     "test": "npm-run-all test:* lint:*",
     "test:app": "npm run build && mocha --reporter mocha-circleci-reporter --recursive test/specs",
     "package:all": "npm-run-all check-build-config package:windows package:mac package:linux",
-    "package:windows": "npm-run-all check-build-config build && build --win --x64 --ia32 --em.name=mattermost --publish=never && npm run manipulate-windows-zip",
+    "package:windows": "npm-run-all check-build-config build && build --win --x64 --ia32 --em.name=uchat --publish=never && npm run manipulate-windows-zip",
     "package:mac": "npm-run-all check-build-config build && build --mac --publish=never",
-    "package:linux": "npm-run-all check-build-config build && build --linux --x64 --ia32 --em.name=mattermost-desktop --publish=never",
+    "package:linux": "npm-run-all check-build-config build && build --linux --x64 --ia32 --em.name=uchat-desktop --publish=never",
     "manipulate-windows-zip": "node scripts/manipulate_windows_zip.js",
     "lint:js": "eslint --ext .js --ext .jsx .",
     "check-build-config": "node scripts/check_build_config.js"

--- a/src/browser/components/ErrorView.jsx
+++ b/src/browser/components/ErrorView.jsx
@@ -3,7 +3,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const {Grid, Row, Col} = require('react-bootstrap');
-const {shell} = require('electron');
+const {shell, remote} = require('electron');
 
 function ErrorView(props) {
   const classNames = ['container', 'ErrorView'];
@@ -37,13 +37,13 @@ function ErrorView(props) {
               md={10}
               lg={8}
             >
-              <h2>{'Cannot connect to Mattermost'}</h2>
+              <h2>{`Cannot connect to ${remote.app.getName()}`}</h2>
               <hr/>
-              <p>{'We\'re having trouble connecting to Mattermost. If refreshing this page (Ctrl+R or Command+R) does not work please verify that:'}</p>
+              <p>{`We\'re having trouble connecting to ${remote.app.getName()}. If refreshing this page (Ctrl+R or Command+R) does not work please verify that:`}</p>
               <br/>
               <ul className='ErrorView-bullets' >
                 <li>{'Your computer is connected to the internet.'}</li>
-                <li>{'The Mattermost URL '}
+                <li>{`The ${remote.app.getName()} URL `}
                   <a
                     onClick={handleClick}
                     href={props.errorInfo.validatedURL}

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -491,7 +491,7 @@ const SettingsPage = createReactClass({
           checked={this.state.showTrayIcon}
           onChange={this.handleChangeShowTrayIcon}
         >{process.platform === 'darwin' ?
-          'Show Mattermost icon in the menu bar' :
+          `Show ${remote.app.getName()} icon in the menu bar` :
           'Show icon in the notification area'}
           <HelpBlock>
             {'Setting takes effect after restarting the app.'}

--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -10,14 +10,14 @@
  *                                          when "enableServerManagement is set to false
  */
 const buildConfig = {
-  defaultTeams: [/*
+  defaultTeams: [
     {
-      name: 'example',
-      url: 'https://example.com'
-    }*/
+      name: 'uChat',
+      url: 'https://uchatx.uberinternal.com'
+    }
   ],
-  helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',
-  enableServerManagement: true
+  helpLink: 'https://team.uberinternal.com/pages/viewpage.action?pageId=123151892',
+  enableServerManagement: false
 };
 
 module.exports = buildConfig;

--- a/src/package.json
+++ b/src/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "mattermost-desktop",
-  "productName": "Mattermost",
-  "desktopName": "Mattermost.desktop",
+  "name": "uchat-desktop",
+  "productName": "uChat",
+  "desktopName": "uChat.desktop",
   "version": "3.7.1",
-  "description": "Mattermost",
+  "description": "uChat",
   "main": "main_bundle.js",
-  "author": "Mattermost, Inc. <feedback@mattermost.com>",
+  "author": "uChat, Inc. <feedback@uchat.com>",
   "homepage": "https://about.mattermost.com",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Chris this is the branch that we can use to test a uChat build from MM master.
It has 4 commits that differ from master. The first two need to be committed back to MM, they're white-labeling thru configs.
The other two are the config files we would pull from our own repository along with all the images files from this PR:
https://github.com/csduarte/uchat-desktop/commit/bea108e
We also need a uChat version of this gif that is displayed while loading. It's a new file:
src/assets/loading.gif